### PR TITLE
Placed "sudo" command recommendation.

### DIFF
--- a/setup-network.sh
+++ b/setup-network.sh
@@ -395,7 +395,7 @@ fi
 if [ "$cleanup" = false -a "$install" = false -a "$installUpgrade" = false ]; then
     echo '
     No Options specified for script execution.
-    Usage command is setup-network.sh [OPTION].
+    Usage command is sudo ./setup-network.sh [OPTION].
     See [OPTION] below:
     ===========================================
     --clean             Cleans/undo all the previously made network configuration/setup.


### PR DESCRIPTION
Placed "sudo" command recommendation in help [OPTION] section before running this script.
Running the script without "sudo" command may cause the permission problems while executions.